### PR TITLE
bump step-certificates to chart 1.27.4 (keep app version)

### DIFF
--- a/charts/step-certificates/Chart.yaml
+++ b/charts/step-certificates/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Wrapper chart for step-certificates
 name: step-certificates
-version: 1.25.0
+version: 1.27.4

--- a/charts/step-certificates/requirements.yaml
+++ b/charts/step-certificates/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: step-certificates
-  version: 1.25.0
+  version: 1.27.4
   repository: https://smallstep.github.io/helm-charts

--- a/charts/step-certificates/values.yaml
+++ b/charts/step-certificates/values.yaml
@@ -2,5 +2,5 @@
 #https://github.com/smallstep/helm-charts/blob/master/step-certificates/values.yaml
 step-certificates:
   image:
-    repository: cr.step.sm/smallstep/step-ca
+    repository: cr.smallstep.com/smallstep/step-ca-bootstrap
     tag: 0.25.3-rc7


### PR DESCRIPTION
Motivation for this is to pull the changes from https://github.com/smallstep/helm-charts/pull/190

Tracked by https://wearezeta.atlassian.net/browse/WPB-9074
